### PR TITLE
Fix bug in remove_resources processor

### DIFF
--- a/bcodmo_processors/bcodmo_pipeline_processors/remove_resources.py
+++ b/bcodmo_processors/bcodmo_pipeline_processors/remove_resources.py
@@ -21,12 +21,16 @@ def remove_resources(
         package.pkg.descriptor['resources'] = new_resources
         yield package.pkg
 
-        it = iter(package)
-        for resource in it:
+        res_list = []
+        for resource in package:
             if matcher.match(resource.res.name):
-                pass
+                for row in resource:
+                    # Make sure the iterator gets all the way through all of the rows before moving on
+                    pass
             else:
-                yield resource
+                res_list.append(resource)
+        for r in res_list:
+            yield r
 
     return func
 


### PR DESCRIPTION
Make sure deleted resources are fully iterated through before moving on to the next processor (otherwise the pipe is flushed too early)

Fixes https://github.com/BCODMO/pipeline-web/issues/88#issuecomment-495413960