### PR TITLE
Fix field type in fixedwidth and convert_to_decimal_degrees

### DIFF
--- a/bcodmo_processors/bcodmo_pipeline_processors/convert_to_decimal_degrees.py
+++ b/bcodmo_processors/bcodmo_pipeline_processors/convert_to_decimal_degrees.py
@@ -115,7 +115,7 @@ def process_resource(rows, missing_data_values):
             if (directional == 'W' or directional == 'S') and decimal_degrees >= 0:
                 decimal_degrees *= -1
 
-            row[output_field] = decimal_degrees
+            row[output_field] = str(decimal_degrees)
 
         yield row
 

--- a/bcodmo_processors/bcodmo_pipeline_processors/parsers/fixedwidth.py
+++ b/bcodmo_processors/bcodmo_pipeline_processors/parsers/fixedwidth.py
@@ -91,4 +91,6 @@ class FixedWidthParser(Parser):
             for index, row in chunk.iterrows():
                 if index == 0:
                     yield (1, None, list(chunk))
-                yield (index + 2, None, row.tolist())
+                l = row.tolist()
+                l = [str(item) for item in l]
+                yield (index + 2, None, l)


### PR DESCRIPTION
This is a bug in frictionless, but we can workaround it very easily.

Fixes https://github.com/BCODMO/pipeline-web/issues/144 and https://github.com/BCODMO/pipeline-web/issues/35

See https://github.com/BCODMO/frictionless-usecases/issues/13